### PR TITLE
Do not produce use statement

### DIFF
--- a/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
+++ b/F-BackEnd/src/xcodeml/f/decompile/XfDecompileDomVisitor.java
@@ -2865,10 +2865,10 @@ public class XfDecompileDomVisitor {
             writer.incrementIndentLevel();
             typeManager.enterScope();
             //////////////////////////////
-            if (true) {
+/*            if (true) {
               writer.writeToken("use xmpf_coarray_decl");
               writer.setupNewLine();
-            }
+            }*/
             //////////////////////////////
 
             // ======
@@ -3260,10 +3260,10 @@ public class XfDecompileDomVisitor {
             writer.incrementIndentLevel();
             typeManager.enterScope();
             //////////////////////////////
-            if (true) {
+/*            if (true) {
               writer.writeToken("use xmpf_coarray_decl");
               writer.setupNewLine();
-            }
+            }*/
             //////////////////////////////
 
             // ======


### PR DESCRIPTION
As we don't use XMP but only the OMNI Compiler infrastructure, this use statement generation is causing us problem. It will probably optional in the next versions of OMNI Compiler. 